### PR TITLE
Do not open addon frame automatically after logging in

### DIFF
--- a/FishingBuddyFrame.lua
+++ b/FishingBuddyFrame.lua
@@ -116,6 +116,7 @@ function FishingBuddyFrame_OnEvent(event)
 	 end
       end
       ToggleFishingBuddyFrame("FishingLocationsFrame");
+      ToggleFishingBuddyFrame("FishingLocationsFrame");
    end
 end
 


### PR DESCRIPTION
It's a bit hacky, but it works. Removing ToggleFishingBuddyFrame() call results in incomplete initialization of the addon frame.